### PR TITLE
Called out running task with elevated privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,3 +289,5 @@ itself:
 fly -t dev execute -c example.yml -o image=. -p
 docker load -i image.tar
 ```
+
+That `-p` at the end is not a typo; it runs the task with elevated privileges.


### PR DESCRIPTION
It's clear that the `task:` entry in the pipeline must run with `privileged: true`. But it's easy to forget to add that flag on the `fly` command line. (Or, in my case, confuse it with the pipeline flag.)