### PR TITLE
Add support for BuildKit secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Next, any of the following optional parameters may be specified:
   DO_THING=false
   ```
 
+* `$BUILDKIT_SECRET_*`: extra secrets which are made available via
+  `--mount=type=secret,id=...`. See [New Docker Build secret information](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information) for more information on build secrets.
+
+  For example, running with `BUILDKIT_SECRET_config=my-repo/config` will allow
+  you to do the following...
+
+  ```
+  RUN --mount=type=secret,id=config cat /run/secrets/config
+  ```
+
 * `IMAGE_ARG_*`: params prefixed with `IMAGE_ARG_*` point to image tarballs
   (i.e. `docker save` format) to preload so that they do not have to be fetched
   during the build. An image reference will be provided as the given build arg

--- a/task.go
+++ b/task.go
@@ -87,6 +87,12 @@ func Build(buildkitd *Buildkitd, outputsDir string, req Request) (Response, erro
 		)
 	}
 
+	for id, src := range cfg.BuildkitSecrets {
+		buildctlArgs = append(buildctlArgs,
+			"--secret", "id="+id+",src="+src,
+		)
+	}
+
 	var builds [][]string
 	var targets []string
 	var imagePaths []string

--- a/task_test.go
+++ b/task_test.go
@@ -242,6 +242,14 @@ func (s *TaskSuite) TestUnpackRootfs() {
 	s.Equal(meta.Env, []string{"PATH=/darkness", "BA=nana"})
 }
 
+func (s *TaskSuite) TestBuildkitSecrets() {
+	s.req.Config.ContextDir = "testdata/buildkit-secret"
+	s.req.Config.BuildkitSecrets = map[string]string{"secret": "testdata/buildkit-secret/secret"}
+
+	_, err := s.build()
+	s.NoError(err)
+}
+
 func (s *TaskSuite) TestRegistryMirrors() {
 	mirror := httptest.NewServer(registry.New())
 	defer mirror.Close()

--- a/testdata/buildkit-secret/Dockerfile
+++ b/testdata/buildkit-secret/Dockerfile
@@ -1,0 +1,3 @@
+# syntax = docker/dockerfile:1.0-experimental
+FROM busybox
+RUN --mount=type=secret,id=secret test "$(cat /run/secrets/secret)" = "hello-world"

--- a/testdata/buildkit-secret/secret
+++ b/testdata/buildkit-secret/secret
@@ -1,0 +1,1 @@
+hello-world

--- a/types.go
+++ b/types.go
@@ -61,6 +61,8 @@ type Config struct {
 	Labels     []string `json:"labels"      envconfig:"optional"`
 	LabelsFile string   `json:"labels_file" envconfig:"optional"`
 
+	BuildkitSecrets map[string]string `json:"buildkit_secrets" envconfig:"optional"`
+
 	// Unpack the OCI image into Concourse's rootfs/ + metadata.json image scheme.
 	//
 	// Theoretically this would go away if/when we standardize on OCI.


### PR DESCRIPTION
Buildkit supports the ability to mount secrets into certain steps of a dockerfile, via `--mount=type=secret,id=[secret-id]`. I've attempted to add support for setting up these secrets via the `BUILDKIT_SECRET_[secret-id]` environment variables.

I've been able to test this in Concourse and build an image which uses credentials passed in via a secret 🙂