### PR TITLE
Labels support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Next, any of the following optional parameters may be specified:
   DO_THING=false
   ```
 
+* `$LABEL_*`: params prefixed with `LABEL_` will be set as image labels.
+  For example `LABEL_foo=bar`, will set the `foo` label to `bar`.
+
+* `$LABELS_FILE` (default empty): path to a file containing labels in
+  the form `foo=bar`, one per line. Empty lines are skipped.
+
 * `$TARGET` (default empty): a target build stage to build.
 
 * `$TARGET_FILE` (default empty): path to a file containing the name of the

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 const buildArgPrefix = "BUILD_ARG_"
+const labelPrefix = "LABEL_"
 
 func main() {
 	req := task.Request{
@@ -22,16 +23,20 @@ func main() {
 	err := envconfig.Init(&req.Config)
 	failIf("parse config from env", err)
 
-	// carry over BUILD_ARG_* vars manually
+	// carry over BUILD_ARG_* and LABEL_* vars manually
 	for _, env := range os.Environ() {
-		if !strings.HasPrefix(env, buildArgPrefix) {
-			continue
+		if strings.HasPrefix(env, buildArgPrefix) {
+			req.Config.BuildArgs = append(
+				req.Config.BuildArgs,
+				strings.TrimPrefix(env, buildArgPrefix),
+			)
 		}
-
-		req.Config.BuildArgs = append(
-			req.Config.BuildArgs,
-			strings.TrimPrefix(env, buildArgPrefix),
-		)
+		if strings.HasPrefix(env, labelPrefix) {
+			req.Config.Labels = append(
+				req.Config.Labels,
+				strings.TrimPrefix(env, labelPrefix),
+			)
+		}
 	}
 
 	logrus.Debugf("read config from env: %#v\n", req.Config)

--- a/task.go
+++ b/task.go
@@ -79,6 +79,12 @@ func Build(buildkitd *Buildkitd, outputsDir string, req Request) (Response, erro
 		)
 	}
 
+	for _, arg := range cfg.Labels {
+		buildctlArgs = append(buildctlArgs,
+			"--opt", "label:"+arg,
+		)
+	}
+
 	logrus.WithFields(logrus.Fields{
 		"buildctl-args": buildctlArgs,
 	}).Debug("building")
@@ -192,6 +198,22 @@ func sanitize(cfg *Config) error {
 			}
 
 			cfg.BuildArgs = append(cfg.BuildArgs, arg)
+		}
+	}
+
+	if cfg.LabelsFile != "" {
+		Labels, err := ioutil.ReadFile(cfg.LabelsFile)
+		if err != nil {
+			return errors.Wrap(err, "read labels file")
+		}
+
+		for _, arg := range strings.Split(string(Labels), "\n") {
+			if len(arg) == 0 {
+				// skip blank lines
+				continue
+			}
+
+			cfg.Labels = append(cfg.Labels, arg)
 		}
 	}
 

--- a/testdata/labels/Dockerfile
+++ b/testdata/labels/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY Dockerfile /

--- a/testdata/labels/label_file
+++ b/testdata/labels/label_file
@@ -1,0 +1,1 @@
+some_other_label=some_other_value

--- a/testdata/labels/label_layer.dockerfile
+++ b/testdata/labels/label_layer.dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY Dockerfile /
+LABEL label_layer=some_label_layer_value

--- a/testdata/labels/labels_file
+++ b/testdata/labels/labels_file
@@ -1,0 +1,2 @@
+some_label=some_value
+some_other_label=some_other_value

--- a/types.go
+++ b/types.go
@@ -57,6 +57,9 @@ type Config struct {
 
 	RegistryMirrors []string `json:"registry_mirrors" envconfig:"REGISTRY_MIRRORS,optional"`
 
+	Labels     []string `json:"labels"      envconfig:"optional"`
+	LabelsFile string   `json:"labels_file" envconfig:"optional"`
+
 	// Unpack the OCI image into Concourse's rootfs/ + metadata.json image scheme.
 	//
 	// Theoretically this would go away if/when we standardize on OCI.


### PR DESCRIPTION
Adds support for adding labels to images at build time via `LABEL_*` or `LABELS_FILE` params.

Fixes: https://github.com/vito/oci-build-task/issues/41