### PR TITLE
feat: allow passing rootdir as opt

### DIFF
--- a/buildkitd.go
+++ b/buildkitd.go
@@ -28,6 +28,7 @@ type Buildkitd struct {
 // BuildkitdOpts to provide to Buildkitd
 type BuildkitdOpts struct {
 	ConfigPath string
+	RootDir    string
 }
 
 func SpawnBuildkitd(req Request, opts *BuildkitdOpts) (*Buildkitd, error) {
@@ -49,6 +50,10 @@ func SpawnBuildkitd(req Request, opts *BuildkitdOpts) (*Buildkitd, error) {
 	}
 
 	buildkitd.rootDir = filepath.Join(os.TempDir(), "buildkitd")
+	if buildkitd.opts != nil && buildkitd.opts.RootDir != "" {
+		buildkitd.rootDir = buildkitd.opts.RootDir
+	}
+
 	err = os.MkdirAll(buildkitd.rootDir, 0755)
 	if err != nil {
 		return nil, errors.Wrap(err, "create root dir")

--- a/buildkitd_test.go
+++ b/buildkitd_test.go
@@ -42,6 +42,17 @@ func (s *BuildkitdSuite) TearDownTest() {
 	s.NoError(err)
 }
 
+func (s *BuildkitdSuite) TestRootDir() {
+	var pathExists bool
+
+	buildkitdDefaultRootDir := "/scratch/buildkitd"
+	if _, err := os.Stat(buildkitdDefaultRootDir); err == nil {
+		pathExists = true
+	}
+
+	s.Assert().False(pathExists)
+}
+
 func (s *BuildkitdSuite) TestNoConfig() {
 	var pathExists bool
 

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -29,7 +29,8 @@ func main() {
 		}
 	}
 
-	buildkitd, err := task.SpawnBuildkitd(req, nil)
+	opts := task.BuildkitdOpts{RootDir: "/scratch/buildkitd"}
+	buildkitd, err := task.SpawnBuildkitd(req, &opts)
 	failIf("start buildkitd", err)
 
 	res, err := task.Build(buildkitd, wd, req)


### PR DESCRIPTION
Allow passing `RootDir` as an opt to `SpawnBuildkitd`.  By default the task will use `/scratch/buildkitd`.  For `SpawnBuildkitd` itself, if ever anything beside the task would call it the default for it would continue to be `filepath.Join(os.TempDir(), "buildkitd")`.

Let me know if you prefer to just hardcode default to `/scratch/buildkitd` inside `SpawnBuildkitd` itself.  Or if you have better ideas on what should be used as a default that would support using overlayfs snapshot driver.

I've built and tested this myself and things are much better now.  👍 

fixes #50 