### PR TITLE
change cache export mode from min to max

### DIFF
--- a/task.go
+++ b/task.go
@@ -83,7 +83,7 @@ func Build(buildkitd *Buildkitd, outputsDir string, req Request) (Response, erro
 
 	if _, err := os.Stat(cacheDir); err == nil {
 		buildctlArgs = append(buildctlArgs,
-			"--export-cache", "type=local,mode=min,dest="+cacheDir,
+			"--export-cache", "type=local,mode=max,dest="+cacheDir,
 		)
 	}
 


### PR DESCRIPTION
With the default min setting only the cache of the final image is exported resulting in poor cache performance for most multi-stage dockerfiles as the heavy work is usually happening in intermediate images.
This will lead to a bigger cache size but improves build time as more parts of multi-stage builds are cached.

Fixes #26

Signed-off-by: Fabian Ruff <fabian.ruff@sap.com>