### PR TITLE
Be more explicit about UNPACK_ROOTFS in example expecting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ like so:
 ```yaml
 plan:
 - task: build-image
+  params:
+    UNPACK_ROOTFS: true
   output_mapping: {image: my-built-image}
 - task: use-image
   image: my-built-image


### PR DESCRIPTION
When debugging someone else's pipeline I read past the text above this several times and kept wondering why we ended up with a "file not found" error.